### PR TITLE
Codyl/version update

### DIFF
--- a/sdk/python/feast/version.py
+++ b/sdk/python/feast/version.py
@@ -11,3 +11,8 @@ def get_version():
     except pkg_resources.DistributionNotFound:
         sdk_version = "unknown"
     return sdk_version
+
+
+"""Contains the version string of Twitter Feast."""
+
+__version__ = '0.11.1+twtr2'

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -129,9 +129,6 @@ with open(README_FILE, "r") as f:
 TAG_REGEX = re.compile(
     r"^(?:[\/\w-]+)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
 )
-TAG_REGEX = re.compile(
-    r"^(?:[\/\w-]+)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
-)
 
 
 class BuildProtoCommand(Command):

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -129,6 +129,9 @@ with open(README_FILE, "r") as f:
 TAG_REGEX = re.compile(
     r"^(?:[\/\w-]+)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
 )
+TAG_REGEX = re.compile(
+    r"^(?:[\/\w-]+)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
+)
 
 
 class BuildProtoCommand(Command):
@@ -188,8 +191,16 @@ class DevelopCommand(develop):
         develop.run(self)
 
 
+# Get version from version module.
+with open('feast/version.py') as fp:
+  globals_dict = {}
+  exec(fp.read(), globals_dict)  # pylint: disable=exec-used
+__version__ = globals_dict['__version__']
+
+
 setup(
     name=NAME,
+    version=__version__,
     author=AUTHOR,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
@@ -218,7 +229,6 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     entry_points={"console_scripts": ["feast=feast.cli:cli"]},
-    use_scm_version={"root": "../..", "relative_to": __file__, "tag_regex": TAG_REGEX},
     setup_requires=["setuptools_scm", "grpcio", "grpcio-tools==1.34.0", "mypy-protobuf", "sphinx!=4.0.0"],
     package_data={
         "": [


### PR DESCRIPTION
Similar to this PR in airflow's twitter-fork (twitter-forks/airflow#29), we should be hardcoding our fork versions when we want to release to 3rdparty/python.