### PR TITLE
Fix path to version.py in setup.py

### DIFF
--- a/sdk/python/feast/version.py
+++ b/sdk/python/feast/version.py
@@ -15,4 +15,4 @@ def get_version():
 
 """Contains the version string of Twitter Feast."""
 
-__version__ = '0.12.0+twtr1'
+__version__ = '0.12.0+twtr2'

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -189,7 +189,9 @@ class DevelopCommand(develop):
 
 
 # Get version from version module.
-with open('sdk/python/feast/version.py') as fp:
+my_path = os.path.abspath(os.path.dirname(__file__))
+path = os.path.join(my_path, "feast/version.py")
+with open(path) as fp:
   globals_dict = {}
   exec(fp.read(), globals_dict)  # pylint: disable=exec-used
 __version__ = globals_dict['__version__']


### PR DESCRIPTION
Got an error
```
      with open('sdk/python/feast/version.py') as fp:
  FileNotFoundError: [Errno 2] No such file or directory: 'sdk/python/feast/version.py'
```
when trying to run `pip install -e "sdk/python[ci]"` from the root. This fixed things, and should also fix running setup.py from any directory.