### PR TITLE
registry-dump output modification

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -685,7 +685,7 @@ class Registry:
             project: Feast project to convert to a dict
         """
         registry_dict = defaultdict(list)
-
+        registry_dict["project"] = project
         for entity in sorted(
             self.list_entities(project=project), key=lambda entity: entity.name
         ):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -310,19 +310,13 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
 @log_exceptions_and_usage
 def registry_dump(repo_config: RepoConfig, repo_path: Path):
     """ For debugging only: output contents of the metadata registry """
-    from colorama import Fore, Style
-
     registry_config = repo_config.get_registry_config()
     project = repo_config.project
     registry = Registry(registry_config=registry_config, repo_path=repo_path)
     registry_dict = registry.to_dict(project=project)
 
-    warning = (
-        "Warning: The registry-dump command is for debugging only and may contain "
-        "breaking changes in the future. No guarantees are made on this interface."
-    )
-    click.echo(f"{Style.BRIGHT}{Fore.YELLOW}{warning}{Style.RESET_ALL}")
-    click.echo(json.dumps(registry_dict, indent=2))
+    click.echo(json.dumps(registry_dict, indent=2, sort_keys=True))
+
 
 
 def cli_check_repo(repo_path: Path):


### PR DESCRIPTION
Signed-off-by: Miray Yuce <myuce@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: 
registry-dump command produces a json with a warning message on top and without the project field that we need in the Feast UI. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

This PR adopts changes from Feast OSS v0.19.0 to produce the json in correct format

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
